### PR TITLE
fix(pkg/costformation): actually fetch the definition from the provided URI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
@@ -21,5 +22,6 @@ require (
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,10 +14,13 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -99,7 +102,10 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -73,6 +73,7 @@ func NewClient(cfg config.Config) (*Client, error) {
 	return client, nil
 }
 
+// setHeaders applies the default headers needed to talk to the API endpoint
 func (c *Client) setHeaders(req *retryablehttp.Request) error {
 	if "" != c.apiKey {
 		req.Header.Set("Authorization", c.apiKey)

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -21,6 +21,7 @@ const (
 	defaultRetryMax    = 3
 	defaultServiceName = "cloudzero-client-go"
 	defaultTimeout     = time.Second * 30
+	defaultContentType = "application/json"
 )
 
 var (
@@ -85,7 +86,7 @@ func (c *Client) setHeaders(req *retryablehttp.Request) error {
 		req.Header.Set("User-Agent", defaultUserAgent)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", defaultContentType)
 
 	return nil
 }

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -1,0 +1,102 @@
+//go:build unit
+
+package http
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/jjttech/cloudzero-client-go/pkg/config"
+)
+
+var _ = Describe("Client", func() {
+	Describe("NewClient", func() {
+		It("returns a new client without any options", func() {
+			cfg := config.New()
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+			Expect(client.client).NotTo(BeNil())
+			Expect(client.client.HTTPClient).NotTo(BeNil())
+
+			// Defaults set by NewClient
+			Expect(client.client.RetryMax).To(Equal(defaultRetryMax))                   // default retries
+			Expect(client.client.Logger).To(BeNil())                                    // Lower logger disabled
+			Expect(client.client.HTTPClient.Timeout).To(Equal(defaultTimeout))          // default timeout
+			Expect(client.client.HTTPClient.Transport).To(Equal(http.DefaultTransport)) // default transport config
+		})
+
+		It("copies the Timeout from config", func() {
+			cfg := config.New()
+			t := 1 * time.Minute
+			cfg.Timeout = &t
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+			Expect(client.client).NotTo(BeNil())
+			Expect(client.client.HTTPClient).NotTo(BeNil())
+
+			Expect(client.client.HTTPClient.Timeout).To(Equal(*cfg.Timeout))
+		})
+
+		It("copies the Transport from config", func() {
+			cfg := config.New()
+			t := http.Transport{}
+			cfg.HTTPTransport = &t
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+			Expect(client.client).NotTo(BeNil())
+			Expect(client.client.HTTPClient).NotTo(BeNil())
+
+			Expect(client.client.HTTPClient.Transport).To(Equal(&t))
+		})
+
+		It("copies RetryMax from config", func() {
+			cfg := config.New()
+			t := 5
+			cfg.RetryMax = &t
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+			Expect(client.client).NotTo(BeNil())
+
+			Expect(client.client.RetryMax).To(Equal(t))
+		})
+
+		It("copies User Agent from config", func() {
+			cfg := config.New()
+			cfg.UserAgent = "test-user-agent"
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+
+			Expect(client.userAgent).To(Equal("test-user-agent"))
+		})
+
+		It("copies API Key from config", func() {
+			cfg := config.New()
+			cfg.APIKey = "test-api-key"
+
+			client, err := NewClient(cfg)
+
+			Expect(err).To(Succeed())
+			Expect(client).NotTo(BeNil())
+
+			Expect(client.apiKey).To(Equal("test-api-key"))
+		})
+	})
+})

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -97,6 +98,57 @@ var _ = Describe("Client", func() {
 			Expect(client).NotTo(BeNil())
 
 			Expect(client.apiKey).To(Equal("test-api-key"))
+		})
+	})
+
+	Describe("setHeaders", func() {
+		It("sets default headers only", func() {
+			client := Client{}
+			req, err := retryablehttp.NewRequest(http.MethodGet, "http://localhost", nil)
+			Expect(err).To(Succeed())
+
+			err = client.setHeaders(req)
+			Expect(err).To(Succeed())
+
+			// Unset
+			h := req.Header.Get("Authorization")
+			Expect(h).To(Equal(""))
+
+			// Default user agent
+			h = req.Header.Get("User-Agent")
+			Expect(h).To(Equal(defaultUserAgent))
+
+			// JSON
+			h = req.Header.Get("Content-Type")
+			Expect(h).To(Equal("application/json"))
+		})
+
+		It("sets the Authorization header", func() {
+			client := Client{
+				apiKey: "test-api-key",
+			}
+			req, err := retryablehttp.NewRequest(http.MethodGet, "http://localhost", nil)
+			Expect(err).To(Succeed())
+
+			err = client.setHeaders(req)
+			Expect(err).To(Succeed())
+
+			h := req.Header.Get("Authorization")
+			Expect(h).To(Equal("test-api-key"))
+		})
+
+		It("sets the User-Agent header", func() {
+			client := Client{
+				userAgent: "test-user-agent",
+			}
+			req, err := retryablehttp.NewRequest(http.MethodGet, "http://localhost", nil)
+			Expect(err).To(Succeed())
+
+			err = client.setHeaders(req)
+			Expect(err).To(Succeed())
+
+			h := req.Header.Get("User-Agent")
+			Expect(h).To(Equal("test-user-agent"))
 		})
 	})
 })

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Client", func() {
 
 			// JSON
 			h = req.Header.Get("Content-Type")
-			Expect(h).To(Equal("application/json"))
+			Expect(h).To(Equal(defaultContentType))
 		})
 
 		It("sets the Authorization header", func() {
@@ -159,6 +159,10 @@ var _ = Describe("Client", func() {
 
 		BeforeEach(func() {
 			server = ghttp.NewServer()
+			server.AppendHandlers(
+				ghttp.VerifyHeader(http.Header{"User-Agent": []string{defaultUserAgent}}),
+				ghttp.VerifyHeader(http.Header{"Content-Type": []string{defaultContentType}}),
+			)
 		})
 
 		AfterEach(func() {
@@ -179,6 +183,7 @@ var _ = Describe("Client", func() {
 				resp, err := client.Get(ctx, server.URL())
 				Expect(err).To(Succeed())
 				Expect(resp).NotTo(BeNil())
+				Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			})
 		})
 
@@ -196,6 +201,7 @@ var _ = Describe("Client", func() {
 				resp, err := client.Post(ctx, server.URL(), nil)
 				Expect(err).To(Succeed())
 				Expect(resp).NotTo(BeNil())
+				Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			})
 		})
 
@@ -213,6 +219,7 @@ var _ = Describe("Client", func() {
 				resp, err := client.Put(ctx, server.URL(), nil)
 				Expect(err).To(Succeed())
 				Expect(resp).NotTo(BeNil())
+				Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			})
 		})
 
@@ -230,6 +237,7 @@ var _ = Describe("Client", func() {
 				resp, err := client.Delete(ctx, server.URL())
 				Expect(err).To(Succeed())
 				Expect(resp).NotTo(BeNil())
+				Expect(server.ReceivedRequests()).Should(HaveLen(1))
 			})
 		})
 	})

--- a/internal/http/client_test.go
+++ b/internal/http/client_test.go
@@ -3,12 +3,14 @@
 package http
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 
 	"github.com/jjttech/cloudzero-client-go/pkg/config"
 )
@@ -149,6 +151,86 @@ var _ = Describe("Client", func() {
 
 			h := req.Header.Get("User-Agent")
 			Expect(h).To(Equal("test-user-agent"))
+		})
+	})
+
+	Describe("Client Actions", func() {
+		var server *ghttp.Server
+
+		BeforeEach(func() {
+			server = ghttp.NewServer()
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Describe("Get", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.VerifyRequest("GET", "/"),
+				)
+			})
+
+			It("should make a basic GET request", func() {
+				ctx := context.TODO()
+				client, _ := NewClient(config.Config{})
+
+				resp, err := client.Get(ctx, server.URL())
+				Expect(err).To(Succeed())
+				Expect(resp).NotTo(BeNil())
+			})
+		})
+
+		Describe("Post", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.VerifyRequest("POST", "/"),
+				)
+			})
+
+			It("should make a basic POST request", func() {
+				ctx := context.TODO()
+				client, _ := NewClient(config.Config{})
+
+				resp, err := client.Post(ctx, server.URL(), nil)
+				Expect(err).To(Succeed())
+				Expect(resp).NotTo(BeNil())
+			})
+		})
+
+		Describe("Put", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.VerifyRequest("PUT", "/"),
+				)
+			})
+
+			It("should make a basic PUT request", func() {
+				ctx := context.TODO()
+				client, _ := NewClient(config.Config{})
+
+				resp, err := client.Put(ctx, server.URL(), nil)
+				Expect(err).To(Succeed())
+				Expect(resp).NotTo(BeNil())
+			})
+		})
+
+		Describe("Delete", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.VerifyRequest("DELETE", "/"),
+				)
+			})
+
+			It("should make a basic DELETE request", func() {
+				ctx := context.TODO()
+				client, _ := NewClient(config.Config{})
+
+				resp, err := client.Delete(ctx, server.URL())
+				Expect(err).To(Succeed())
+				Expect(resp).NotTo(BeNil())
+			})
 		})
 	})
 })


### PR DESCRIPTION
Cleanup the TODO statement on fetching the actual content, and pass it to the decoder, then return to the caller.